### PR TITLE
feat: add support for squared conversions

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,24 +8,57 @@ function prettify (value, shouldPrettify) {
   return parts.join('.')
 }
 
+/**
+ * Utility for checking conversion validity
+ * Errors if a length measurement is trying to convert to an area measurement
+ * and vice versa
+ * @param {string} fromCategoryType the incoming category type i.e. length or area
+ * @param {string} toCategoryType the outbound category type i.e. length or area
+ */
+function isValidConversion (fromCategoryType, toCategoryType) {
+  if (fromCategoryType !== toCategoryType) {
+    var errorSnippet =
+      fromCategoryType === 'area'
+        ? 'an area measurement to a length measurement'
+        : 'a length measurement to an area measurement'
+    throw new Error(
+      `Invalid conversion. You are trying to convert ${errorSnippet}.`
+    )
+  }
+}
+
 var modifiers = {
   km: .001,
+  km2: .000001,
   hm: .01,
+  hm2: .0001, 
   dam: .1,
+  dam2: .01,
   m: 1,
+  m2: 1,
   dm: 10,
+  dm2: 100,
   cm: 100,
-  mm: 1000
+  cm2: 10000,
+  mm: 1000,
+  mm2: 1000000
 }
 
 var types = {
-  km: 1000,
-  hm: 100,
-  dam: 10,
-  m: 1,
-  dm: .1,
-  cm: .01,
-  mm: .001
+  km: { value: 1000, category: 'length' },
+  km2: { value: 1000000, category: 'area' },
+  hm: { value: 100, category: 'length' },
+  hm2: { value: 10000, category: 'area' },
+  dam: { value: 10, category: 'length' },
+  dam2: { value: 100, category: 'area' },
+  m: { value: 1, category: 'length' },
+  m2: { value: 1, category: 'area' },
+  dm: { value: .1, category: 'length' },
+  dm2: { value: .01, category: 'area' },
+  cm: { value: .01, category: 'length' },
+  cm2: { value: .0001, category: 'area' },
+  mm: { value: .001, category: 'length' },
+  mm2: { value: .000001, category: 'area' },
 }
 
 function Pretty (value) {
@@ -45,36 +78,87 @@ Pretty.prototype.input = function (type) {
 }
 
 Pretty.prototype.km = function () {
-  return prettify((this.value * this.type) * modifiers.km, this.prettify) + 'km'
+  isValidConversion(this.type.category, 'length')
+  return prettify((this.value * this.type.value) * modifiers.km, this.prettify) + 'km'
+}
+
+Pretty.prototype.km2 = function () {
+  isValidConversion(this.type.category, 'area')
+  return prettify((this.value * this.type.value) * modifiers.km2, this.prettify) + 'km2'
 }
 
 Pretty.prototype.hm = function () {
-  return prettify((this.value * this.type) * modifiers.hm, this.prettify) + 'hm'
+  isValidConversion(this.type.category, 'length')
+  return prettify((this.value * this.type.value) * modifiers.hm, this.prettify) + 'hm'
+}
+
+Pretty.prototype.hm2 = function () {
+  isValidConversion(this.type.category, 'area')
+  return prettify((this.value * this.type.value) * modifiers.hm2, this.prettify) + 'hm2'
 }
 
 Pretty.prototype.dam = function () {
-  return prettify((this.value * this.type) * modifiers.dam, this.prettify) + 'dam'
+  isValidConversion(this.type.category, 'length')
+  return prettify((this.value * this.type.value) * modifiers.dam, this.prettify) + 'dam'
+}
+
+Pretty.prototype.dam2 = function () {
+  isValidConversion(this.type.category, 'area')
+  return prettify((this.value * this.type.value) * modifiers.dam2, this.prettify) + 'dam2'
 }
 
 Pretty.prototype.m = function () {
-  return prettify((this.value * this.type) * modifiers.m, this.prettify) + 'm'
+  isValidConversion(this.type.category, 'length')
+  return prettify((this.value * this.type.value) * modifiers.m, this.prettify) + 'm'
+}
+
+Pretty.prototype.m2 = function () {
+  isValidConversion(this.type.category, 'area')
+  return prettify((this.value * this.type.value) * modifiers.m2, this.prettify) + 'm2'
 }
 
 Pretty.prototype.dm = function () {
-  return prettify((this.value * this.type) * modifiers.dm, this.prettify) + 'dm'
+  isValidConversion(this.type.category, 'length')
+  return prettify((this.value * this.type.value) * modifiers.dm, this.prettify) + 'dm'
+}
+
+Pretty.prototype.dm2 = function () {
+  isValidConversion(this.type.category, 'area')
+  return prettify((this.value * this.type.value) * modifiers.dm2, this.prettify) + 'dm2'
 }
 
 Pretty.prototype.cm = function () {
-  return prettify((this.value * this.type) * modifiers.cm, this.prettify) + 'cm'
+  isValidConversion(this.type.category, 'length')
+  return prettify((this.value * this.type.value) * modifiers.cm, this.prettify) + 'cm'
+}
+
+Pretty.prototype.cm2 = function () {
+  isValidConversion(this.type.category, 'area')
+  return prettify((this.value * this.type.value) * modifiers.cm2, this.prettify) + 'cm2'
 }
 
 Pretty.prototype.mm = function () {
-  return prettify((this.value * this.type) * modifiers.mm, this.prettify) + 'mm'
+  isValidConversion(this.type.category, 'length')
+  return prettify((this.value * this.type.value) * modifiers.mm, this.prettify) + 'mm'
+}
+
+Pretty.prototype.mm2 = function () {
+  isValidConversion(this.type.category, 'area')
+  return prettify((this.value * this.type.value) * modifiers.mm2, this.prettify) + 'mm2'
 }
 
 Pretty.prototype.humanize = function () {
-  var value = this.type * this.value
+  var value = this.type.value * this.value
+  var category = this.type.category
   this.prettify = true
+
+  if (category === 'area') {
+    if (value >= 1000000) return this.km2()
+    if (value >= 1) return this.m2()
+    if (value >= .5) return this.m2()
+    if (value >= .1) return this.cm2()
+    return this.mm2()
+  }
   if (value >= 1000) return this.km()
   if (value >= 1) return this.m()
   if (value >= .5) return this.m()

--- a/test/humanize.js
+++ b/test/humanize.js
@@ -5,50 +5,100 @@ test('humanize meter to km', function (t) {
   t.is(pretty(1500).humanize(), '1.5km')
 })
 
+test('humanize square meter to square km', function (t) {
+  t.is(pretty(1500000).input('m2').humanize(), '1.5km2')
+})
+
 test('humanize large meter to km', function (t) {
   t.is(pretty(15001100).humanize(), '15,001.1km')
   t.is(pretty(1000000).humanize(), '1,000km')
   t.is(pretty(10000000).humanize(), '10,000km')
 })
 
+test('humanize large square meter to km2', function (t) {
+  t.is(pretty(15001100000).input('m2').humanize(), '15,001.1km2')
+  t.is(pretty(1000000000).input('m2').humanize(), '1,000km2')
+  t.is(pretty(10000000000).input('m2').humanize(), '10,000km2')
+})
+
 test('humanize meter digits to km', function (t) {
   t.is(pretty(1500.1100).humanize(), '1.5km')
+})
+
+test('humanize square meter digits to km2', function (t) {
+  t.is(pretty(1500000.1100).input('m2').humanize(), '1.5km2')
 })
 
 test('humanize meter digits to m', function (t) {
   t.is(pretty(1.1100).input('m').humanize(), '1.11m')
 })
 
+test('humanize square meter digits to m2', function (t) {
+  t.is(pretty(1.1100).input('m2').humanize(), '1.11m2')
+})
+
 test('humanize meter to m', function (t) {
   t.is(pretty(15).humanize(), '15m')
+})
+
+test('humanize square meter to m', function (t) {
+  t.is(pretty(15).input('m2').humanize(), '15m2')
 })
 
 test('humanize meter to m', function (t) {
   t.is(pretty(1.5).humanize(), '1.5m')
 })
 
+test('humanize square meter to m', function (t) {
+  t.is(pretty(1.5).input('m2').humanize(), '1.5m2')
+})
+
 test('humanize meter to m', function (t) {
   t.is(pretty(.5).humanize(), '0.5m')
+})
+
+test('humanize square meter to m', function (t) {
+  t.is(pretty(.5).input('m2').humanize(), '0.5m2')
 })
 
 test('humanize meter to cm', function (t) {
   t.is(pretty(.4).humanize(), '40cm')
 })
 
+test('humanize square meter to cm2', function (t) {
+  t.is(pretty(.4).input('m2').humanize(), '4,000cm2')
+})
+
 test('humanize meter to mm', function (t) {
   t.is(pretty(.05).humanize(), '50mm')
+})
+
+test('humanize square meter to mm2', function (t) {
+  t.is(pretty(.05).input('m2').humanize(), '50,000mm2')
 })
 
 test('input: humanize cm', function (t) {
   t.is(pretty(150).input('cm').humanize(), '1.5m')
 })
 
+test('input: humanize cm2', function (t) {
+  t.is(pretty(15000).input('cm2').humanize(), '1.5m2')
+})
+
 test('input: humanize cm', function (t) {
   t.is(pretty(0.5).input('cm').humanize(), '5mm')
 })
 
+test('input: humanize cm2', function (t) {
+  t.is(pretty(0.5).input('cm2').humanize(), '50mm2')
+})
+
 test('input: humanize mm', function (t) {
   t.is(pretty(1500).input('mm').humanize(), '1.5m')
+})
+
+test('input: humanize mm2', function (t) {
+  t.is(pretty(1500000).input('mm2').humanize(), '1.5m2')
 })
 
 test('input: humanize zero', function (t) {

--- a/test/index.js
+++ b/test/index.js
@@ -1,64 +1,292 @@
 var test = require('ava')
 var pretty = require('..')
 
+// kilometer conversions
+test('input: km to hm', function (t) {
+  t.is(pretty(1).input('km').hm(), '10hm')
+})
+test('input: km to dam', function (t) {
+  t.is(pretty(1).input('km').dam(), '100dam')
+})
+test('input: km to m', function (t) {
+  t.is(pretty(1).input('km').m(), '1000m')
+})
+test('input: km to dm', function (t) {
+  t.is(pretty(1).input('km').dm(), '10000dm')
+})
+test('input: km to cm', function (t) {
+  t.is(pretty(1).input('km').cm(), '100000cm')
+})
+test('input: km to mm', function (t) {
+  t.is(pretty(1).input('km').mm(), '1000000mm')
+})
+
+// squared kilometer conversions
+test('input: km2 to hm2', function (t) {
+  t.is(pretty(1).input('km2').hm2(), '100hm2')
+})
+test('input: km2 to dam2', function (t) {
+  t.is(pretty(1).input('km2').dam2(), '10000dam2')
+})
+test('input: km2 to m2', function (t) {
+  t.is(pretty(1).input('km2').m2(), '1000000m2')
+})
+test('input: km2 to dm2', function (t) {
+  t.is(pretty(1).input('km2').dm2(), '100000000dm2')
+})
+test('input: km2 to cm2', function (t) {
+  t.is(pretty(1).input('km2').cm2(), '10000000000cm2')
+})
+test('input: km2 to mm2', function (t) {
+  t.is(pretty(1).input('km2').mm2(), '1000000000000mm2')
+})
+
+// hectometer conversions
+test('input: hm to km', function (t) {
+  t.is(pretty(1).input('hm').km(), '0.1km')
+})
+test('input: hm to dam', function (t) {
+  t.is(pretty(1).input('hm').dam(), '10dam')
+})
+test('input: hm to m', function (t) {
+  t.is(pretty(1).input('hm').m(), '100m')
+})
+test('input: hm to dm', function (t) {
+  t.is(pretty(1).input('hm').dm(), '1000dm')
+})
+test('input: hm to cm', function (t) {
+  t.is(pretty(1).input('hm').cm(), '10000cm')
+})
+test('input: hm to mm', function (t) {
+  t.is(pretty(1).input('hm').mm(), '100000mm')
+})
+
+// squared hectometer conversions
+test('input: hm2 to km2', function (t) {
+  t.is(pretty(1).input('hm2').km2(), '0.01km2')
+})
+test('input: hm2 to dam2', function (t) {
+  t.is(pretty(1).input('hm2').dam2(), '100dam2')
+})
+test('input: hm2 to m2', function (t) {
+  t.is(pretty(1).input('hm2').m2(), '10000m2')
+})
+test('input: hm2 to dm2', function (t) {
+  t.is(pretty(1).input('hm2').dm2(), '1000000dm2')
+})
+test('input: hm2 to cm2', function (t) {
+  t.is(pretty(1).input('hm2').cm2(), '100000000cm2')
+})
+test('input: hm2 to mm2', function (t) {
+  t.is(pretty(1).input('hm2').mm2(), '10000000000mm2')
+})
+
+// decameter conversions
+test('input: dam to km', function (t) {
+  t.is(pretty(1).input('dam').km(), '0.01km')
+})
+test('input: dam to hm', function (t) {
+  t.is(pretty(1).input('dam').hm(), '0.1hm')
+})
+test('input: dam to m', function (t) {
+  t.is(pretty(1).input('dam').m(), '10m')
+})
+test('input: dam to dm', function (t) {
+  t.is(pretty(1).input('dam').dm(), '100dm')
+})
+test('input: dam to cm', function (t) {
+  t.is(pretty(1).input('dam').cm(), '1000cm')
+})
+test('input: dam to mm', function (t) {
+  t.is(pretty(1).input('dam').mm(), '10000mm')
+})
+
+// squared decameter conversions
+test('input: dam2 to km2', function (t) {
+  t.is(pretty(1).input('dam2').km2(), '0.00009999999999999999km2')
+})
+test('input: dam2 to hm2', function (t) {
+  t.is(pretty(1).input('dam2').hm2(), '0.01hm2')
+})
+test('input: dam2 to m2', function (t) {
+  t.is(pretty(1).input('dam2').m2(), '100m2')
+})
+test('input: dam2 to dm2', function (t) {
+  t.is(pretty(1).input('dam2').dm2(), '10000dm2')
+})
+test('input: dam2 to cm2', function (t) {
+  t.is(pretty(1).input('dam2').cm2(), '1000000cm2')
+})
+test('input: dam2 to mm2', function (t) {
+  t.is(pretty(1).input('dam2').mm2(), '100000000mm2')
+})
+
+// meter conversions
 test('default 1 meter to m', function (t) {
   t.is(pretty().m(), '1m')
 })
-
 test('meter to km', function (t) {
   t.is(pretty(1500).km(), '1.5km')
 })
-
 test('meter to hm', function (t) {
   t.is(pretty(1500).hm(), '15hm')
 })
-
 test('meter to dam', function (t) {
   t.is(pretty(1500).dam(), '150dam')
 })
-
 test('meter to m', function (t) {
   t.is(pretty(150).m(), '150m')
 })
-
 test('meter to dm', function (t) {
   t.is(pretty(150).dm(), '1500dm')
 })
-
 test('meter to cm', function (t) {
   t.is(pretty(150).cm(), '15000cm')
 })
-
 test('meter to mm', function (t) {
   t.is(pretty(150).mm(), '150000mm')
 })
 
+// squared meter conversions
+test('input: m2 to km2', function (t) {
+  t.is(pretty(1).input('m2').km2(), '0.000001km2')
+})
+test('input: m2 to hm2', function (t) {
+  t.is(pretty(1).input('m2').hm2(), '0.0001hm2')
+})
+test('input: m2 to dam2', function (t) {
+  t.is(pretty(1).input('m2').dam2(), '0.01dam2')
+})
+test('input: m2 to dm2', function (t) {
+  t.is(pretty(1).input('m2').dm2(), '100dm2')
+})
+test('input: m2 to cm2', function (t) {
+  t.is(pretty(1).input('m2').cm2(), '10000cm2')
+})
+test('input: m2 to mm2', function (t) {
+  t.is(pretty(1).input('m2').mm2(), '1000000mm2')
+})
+
+// decimeter conversions
+test('input: dm to km', function (t) {
+  t.is(pretty(10000).input('dm').km(), '1km')
+})
+test('input: dm to hm', function (t) {
+  t.is(pretty(10000).input('dm').hm(), '10hm')
+})
+test('input: dm to dam', function (t) {
+  t.is(pretty(10000).input('dm').dam(), '100dam')
+})
+test('input: dm to m', function (t) {
+  t.is(pretty(10000).input('dm').m(), '1000m')
+})
+test('input: dm to cm', function (t) {
+  t.is(pretty(10000).input('dm').cm(), '100000cm')
+})
+test('input: dm to mm', function (t) {
+  t.is(pretty(10000).input('dm').mm(), '1000000mm')
+})
+
+// squared decimeter conversions
+test('input: dm2 to km2', function (t) {
+  t.is(pretty(150000).input('dm2').km2(), '0.0015km2')
+})
+test('input: dm2 to hm2', function (t) {
+  t.is(pretty(10000).input('dm2').hm2(), '0.01hm2')
+})
+test('input: dm2 to dam2', function (t) {
+  t.is(pretty(10000).input('dm2').dam2(), '1dam2')
+})
+test('input: dm2 to m2', function (t) {
+  t.is(pretty(10000).input('dm2').m2(), '100m2')
+})
+test('input: dm2 to cm2', function (t) {
+  t.is(pretty(10000).input('dm2').cm2(), '1000000cm2')
+})
+test('input: dm2 to mm2', function (t) {
+  t.is(pretty(10000).input('dm2').mm2(), '100000000mm2')
+})
+
+// centimeter conversions
 test('input: cm to km', function (t) {
   t.is(pretty(1500).input('cm').km(), '0.015km')
 })
-
 test('input: cm to hm', function (t) {
   t.is(pretty(1500).input('cm').hm(), '0.15hm')
 })
-
 test('input: cm to dam', function (t) {
   t.is(pretty(1500).input('cm').dam(), '1.5dam')
 })
-
 test('input: cm to m', function (t) {
   t.is(pretty(150).input('cm').m(), '1.5m')
 })
-
 test('input: cm to dm', function (t) {
   t.is(pretty(150).input('cm').dm(), '15dm')
 })
-
 test('input: cm to cm', function (t) {
   t.is(pretty(150).input('cm').cm(), '150cm')
 })
-
 test('input: cm to mm', function (t) {
   t.is(pretty(150).input('cm').mm(), '1500mm')
 })
 
+// squared centimeter conversions
+test('input: cm2 to km2', function (t) {
+  t.is(pretty(10000000).input('cm2').km2(), '0.001km2')
+})
+test('input: cm2 to hm2', function (t) {
+  t.is(pretty(10000000).input('cm2').hm2(), '0.1hm2')
+})
+test('input: cm2 to dam2', function (t) {
+  t.is(pretty(10000000).input('cm2').dam2(), '10dam2')
+})
+test('input: cm2 to m2', function (t) {
+  t.is(pretty(10000000).input('cm2').m2(), '1000m2')
+})
+test('input: cm2 to dm2', function (t) {
+  t.is(pretty(10000000).input('cm2').dm2(), '100000dm2')
+})
+test('input: cm2 to mm2', function (t) {
+  t.is(pretty(10000000).input('cm2').mm2(), '1000000000mm2')
+})
+
+// millimeter conversions
+test('input: mm to km', function (t) {
+  t.is(pretty(1000000).input('mm').km(), '1km')
+})
+test('input: mm to hm', function (t) {
+  t.is(pretty(1000000).input('mm').hm(), '10hm')
+})
+test('input: mm to dam', function (t) {
+  t.is(pretty(1000000).input('mm').dam(), '100dam')
+})
+test('input: mm to m', function (t) {
+  t.is(pretty(1000000).input('mm').m(), '1000m')
+})
+test('input: mm to dm', function (t) {
+  t.is(pretty(1000000).input('mm').dm(), '10000dm')
+})
+test('input: mm to cm', function (t) {
+  t.is(pretty(1000000).input('mm').cm(), '100000cm')
+})
+
+// squared millimeter conversions
+test('input: mm2 to km2', function (t) {
+  t.is(pretty(1500000000).input('mm2').km2(), '0.0015km2')
+})
+test('input: mm2 to hm2', function (t) {
+  t.is(pretty(10000000).input('mm2').hm2(), '0.001hm2')
+})
+test('input: mm2 to dam2', function (t) {
+  t.is(pretty(10000000).input('mm2').dam2(), '0.1dam2')
+})
+test('input: mm2 to m2', function (t) {
+  t.is(pretty(10000000).input('mm2').m2(), '10m2')
+})
+test('input: mm2 to dm2', function (t) {
+  t.is(pretty(10000000).input('mm2').dm2(), '1000dm2')
+})
+test('input: mm2 to cm2', function (t) {
+  t.is(pretty(10000000).input('mm2').cm2(), '100000cm2')
+})
 

--- a/test/index.js
+++ b/test/index.js
@@ -290,3 +290,19 @@ test('input: mm2 to cm2', function (t) {
   t.is(pretty(10000000).input('mm2').cm2(), '100000cm2')
 })
 
+
+// invalid conversions
+test('converting from length to area throws error', function (t) {
+  const error = t.throws(() => pretty(1).input('m').km2())
+  t.is(
+    error.message,
+    'Invalid conversion. You are trying to convert a length measurement to an area measurement.'
+  )
+})
+test('converting from area to length throws error', function (t) {
+  const error = t.throws(() => pretty(1).input('km2').m())
+  t.is(
+    error.message,
+    'Invalid conversion. You are trying to convert an area measurement to a length measurement.'
+  )
+})


### PR DESCRIPTION
### Overview

Discovered this morning that converting between units like meters to kilometers requires different conversion factors than converting between square meters and square meters. This PR covers the work required to support squared unit conversions. The following updates were made:

- add modifiers for km2, hm2, dam2, m2, dm2, cm2, mm2
- restructure the types variable so measurement type (i.e. length or area) can be captured along with the conversion factor
- add validation utility to throw error if user tries to convert from a length to a measurement and vice versa
- add converters for km2, hm2, dam2, m2, dm2, cm2, mm2
- add logic to humanize for squared units
- add tests for squared units
